### PR TITLE
Let non-api routes be handled by reach router

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser');
 const morgan = require('morgan');
 const cors = require('cors');
 const mongoose = require('mongoose');
+const path = require('path');
 
 /**** Configuration ****/
 const port = (process.env.PORT || 8080);
@@ -40,6 +41,12 @@ app.post('/api/kittens/:id/hobbies', (req, res) => {
     kittenDAL.addHobby(req.params.id, req.body.hobby)
         .then(updatedKitten => res.json(updatedKitten));
 });
+
+// "Redirect" all get requests (except for the routes specified above) to React's entry point (index.html) to be handled by Reach router
+// It's important to specify this route as the very last one to prevent overriding all of the other routes
+app.get('*', (req, res) =>
+    res.sendFile(path.resolve('..', 'client', 'build', 'index.html'))
+);
 
 /**** Start ****/
 const url = (process.env.MONGO_URL || 'mongodb://localhost/kitten_db');


### PR DESCRIPTION
I tried to solve the problem with directly accessing child routes (for example accessing https://kittens-api.herokuapp.com/kitten/5d9c824bc5409100175abfc8 directly will return 404 from the server).

I used this solution in one of my Angular apps, where we simply redirect all requests to index.html to be handled by the SPA router. Tested it on a locally run express server without any issues.

When serving the app in production (with the express server instead of react’s dev server), all routes were picked up by express (accessing child routes directly resulted in 404 from express)